### PR TITLE
Merge successful thread-separation changes to main

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -103,7 +103,7 @@ void MandelbrotApplication::initializeGrid()
 
 void MandelbrotApplication::initializeShading()
 {
-    shading.setShadingFunction(0);
+    shading.setShadingFunction(2);
 }
 
 void MandelbrotApplication::initializeRenderTexture()

--- a/src/application.hpp
+++ b/src/application.hpp
@@ -2,6 +2,7 @@
 #define _MANDELBROTAPPLICATION
 
 #include <chrono>
+#include <thread>
 
 #include <SDL2/SDL.h>
 
@@ -35,7 +36,8 @@ private:
 
     SDL_Point mousePosition;
 
-    MandelbrotGrid mandelbrotGrid; 
+    MandelbrotGrid mandelbrotGrid;
+    std::thread calculationThread;
 
     Shading shading;
     
@@ -49,8 +51,6 @@ private:
     void initializeRenderTexture();
 
     void handleEvents();
-
-    void tick();
 
     void draw();
 };

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -21,18 +21,26 @@ MandelbrotGrid::MandelbrotGrid()
 
 void MandelbrotGrid::initializeGrid(int width, int height, double viewCenterReal, double viewCenterImag, double viewScale)
 {
-    m_viewCenter.set(viewCenterReal, viewCenterImag);
-    m_viewScale = viewScale;
+    {
+        std::lock_guard<std::mutex> lock(calculationMutex);
+
+        m_viewCenter.set(viewCenterReal, viewCenterImag);
+        m_viewScale = viewScale;
+    }
 
     resizeGrid(width, height);
 }
 
 void MandelbrotGrid::resizeGrid(int width, int height)
 {
-    m_width = width;
-    m_height = height;
+    {
+        std::lock_guard<std::mutex> lock(calculationMutex);
 
-    aspectRatio = static_cast<double>(m_width) / static_cast<double>(m_height);
+        m_width = width;
+        m_height = height;
+
+        aspectRatio = static_cast<double>(m_width) / static_cast<double>(m_height);
+    }
 
     resetGrid();
 }
@@ -174,7 +182,7 @@ void MandelbrotGrid::iterateGrid()
     {
         {
             std::lock_guard<std::mutex> lock(calculationMutex);
-    
+
             invalidateCurrentIteration = false;
         }
         for (int x = 0; x < m_width; x++)

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -21,31 +21,9 @@ public:
 
     void stop();
 
-    void tick();
-
-    int width();
-    int height();
-
-    double getViewScale();
-
-    Complex valueAt(int x, int y);
-
-    bool divergesAt(int x, int y);
-
-    int getIterationCount();
-
-    int getEscapeCount();
-
     int getMaxIterationCount();
 
-    int getEscapeIterationCounter(int i);
-
-    int getEscapeIterationCounterSum(int i);
-    double getEscapeIterationCounterSum(double i);
-
-    double getEscapeRadius();
-
-    int iterationsAt(int x, int y);
+    void getFrameData(int &escapeCount, std::vector<double> &magnitudeGrid, std::vector<int> &iterationGrid, std::vector<int> &escapeIterationCounterSums);
 
     void zoomIn(double factor);
     void zoomOut(double factor);
@@ -57,9 +35,15 @@ public:
 private:
     std::vector<Complex> grid;
     std::vector<int> iterationGrid;
+
+    std::vector<double> safe_magnitudeGrid;
+    std::vector<int> safe_iterationGrid;
+
     std::vector<int> escapeIterationCounter;
-    std::vector<int> escapeIterationCounterSums;
+    std::vector<int> safe_escapeIterationCounterSums;
+
     int m_escapeCount;
+    int safe_escapeCount;
     int m_iterationCount;
     int m_iterationMaximum;
     double m_escapeRadius;
@@ -70,6 +54,7 @@ private:
 
     bool isRunning;
     std::mutex calculationMutex;
+    bool invalidateCurrentIteration;
 
     Complex mapToComplex(double x, double y);
 

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -2,6 +2,7 @@
 #define _MANDELBROTGRID
 
 #include <vector>
+#include <mutex>
 
 #include "complex.hpp"
 
@@ -15,6 +16,10 @@ public:
     void resizeGrid(int width, int height);
 
     void resetGrid();
+
+    void calculationLoop();
+
+    void stop();
 
     void tick();
 
@@ -62,6 +67,9 @@ private:
     double aspectRatio;
     Complex m_viewCenter;
     double m_viewScale;
+
+    bool isRunning;
+    std::mutex calculationMutex;
 
     Complex mapToComplex(double x, double y);
 


### PR DESCRIPTION
The program previously executed everything in one thread, meaning that rendering and calculations could really slow each other down.

The calculations have now been separated into their own thread, and all communication between rendering and data have been reduced to one call / frame and being safe and consistent over each frame.

There are still some small problems with constantly locking and unlocking mutexes, but everything runs better than previously.